### PR TITLE
Retrieval window

### DIFF
--- a/grtr/train.py
+++ b/grtr/train.py
@@ -67,7 +67,7 @@ def evaluate(in_model, in_tokenizer, in_data_loader, args):
             lm_labels_flat_shifted = lm_labels[..., 1:].contiguous().view(-1)
             results = (lm_logits_flat_shifted, mc_logits), (lm_labels_flat_shifted, mc_labels)
             loss += loss_fn(results[0][0], results[1][0]) / len(in_data_loader)
-            batch_acc = ((mc_labels.eq(mc_logits.max(-1)[1])).sum()) / mc_labels.shape[0]
+            batch_acc = ((mc_labels.eq(mc_logits.max(-1)[1])).sum()) / float(mc_labels.shape[0])
             acc += batch_acc / len(in_data_loader)
     return {'loss': loss.item() if isinstance(loss, torch.Tensor) else loss,
             'acc': acc.item() if isinstance(loss, torch.Tensor) else acc}

--- a/grtr/utils.py
+++ b/grtr/utils.py
@@ -453,10 +453,10 @@ def embed_dialogue(context, response, tokenizer, encoder, args, encodings_cache=
     if response is None:
         response = []
 
-    dialogue_id = hashlib.sha256(str(context + response).encode('utf-8')).digest()
+    dialogue_id = hashlib.sha256(str(context + ['|'] + response).encode('utf-8')).digest()
     if dialogue_id in encodings_cache:
         logging.info('Encodings cache hit')
-        logging.info(str(context + response) + ' --> ' + str(dialogue_id))
+        logging.info(str(context + ['|'] + response) + ' --> ' + str(dialogue_id))
         return encodings_cache[dialogue_id]
 
     instance, sequence = build_input_from_segments(context, response, tokenizer, with_eos=True)

--- a/grtr/utils.py
+++ b/grtr/utils.py
@@ -10,6 +10,7 @@ from collections import deque, defaultdict, Counter
 from heapq import heappop, heappush, heappushpop
 from itertools import chain
 from zipfile import ZipFile
+import hashlib
 
 import numpy as np
 import torch
@@ -452,9 +453,10 @@ def embed_dialogue(context, response, tokenizer, encoder, args, encodings_cache=
     if response is None:
         response = []
 
-    dialogue_id = str(context + response).encode('utf-8')
+    dialogue_id = hashlib.sha256(str(context + response).encode('utf-8')).digest()
     if dialogue_id in encodings_cache:
         logging.info('Encodings cache hit')
+        logging.info(str(context + response) + ' --> ' + str(dialogue_id))
         return encodings_cache[dialogue_id]
 
     instance, sequence = build_input_from_segments(context, response, tokenizer, with_eos=True)

--- a/scripts/predict_generate_and_rank
+++ b/scripts/predict_generate_and_rank
@@ -162,19 +162,23 @@ def main(args):
 
                     fine_tune(model, tokenizer, optimizer, supset, args, amp=amp_handle)
 
+                encodings_cache = {}
                 if args.local_rank in [0, -1]:
                     turn_to_predict = spec['predict_turn']
+                    ret_window = (turn_to_predict - args.retrieval_window // 2,
+                                  turn_to_predict + (args.retrieval_window - 1) // 2)
                     target_dlg_history = dialogue['turns'][:turn_to_predict]
                     target_dlg_history = target_dlg_history[-(args.max_history * 2 - 1):]
                     support_contexts, support_responses = [], []
                     for support_dialogue in supset:
-                        if not turn_to_predict < len(support_dialogue['turns']):
-                            continue
-                        support_dlg_history = support_dialogue['turns'][:turn_to_predict]
-                        support_dlg_history = support_dlg_history[-(args.max_history * 2 - 1):]
-                        support_response = support_dialogue['turns'][turn_to_predict]
-                        support_contexts.append(support_dlg_history)
-                        support_responses.append(support_response)
+                        for sup_turn_to_predict in range(ret_window[0], ret_window[1] + 1):
+                            if not sup_turn_to_predict < len(support_dialogue['turns']):
+                                continue
+                            support_dlg_history = support_dialogue['turns'][:turn_to_predict]
+                            support_dlg_history = support_dlg_history[-(args.max_history * 2 - 1):]
+                            support_response = support_dialogue['turns'][turn_to_predict]
+                            support_contexts.append(support_dlg_history)
+                            support_responses.append(support_response)
                     with torch.no_grad():
                         out_ids = generate_and_rank(support_contexts,
                                                     support_responses,
@@ -182,7 +186,8 @@ def main(args):
                                                     tokenizer,
                                                     model,
                                                     transformer_encoder,
-                                                    args)
+                                                    args,
+                                                    encodings_cache=encodings_cache)
                     print_prediction(dialogue, out_ids, tokenizer, spec['predict_turn'], nlgeval)
 
 
@@ -204,6 +209,11 @@ def parse_args():
                         type=float,
                         default=0.1,
                         help="Ratio of support dialogues used for evaluation of fine-tuning")
+    parser.add_argument("--retrieval_window",
+                        type=int,
+                        default=5,
+                        help="Window of turns to consider as retrieval candidates"
+                        "(tgt_turn - window // 2, tgt_turn + (window - 1) // 2)")
     parser.add_argument("--lr", type=float, default=6.25e-5, help="Learning rate")
     parser.add_argument("--lm_coef", type=float, default=1.0, help="LM loss coefficient")
     parser.add_argument("--mc_coef", type=float, default=1.0, help="Multiple-choice loss coefficient")

--- a/scripts/predict_generate_and_rank
+++ b/scripts/predict_generate_and_rank
@@ -146,6 +146,7 @@ def main(args):
                                                    args,
                                                    filenames=[domain_name],
                                                    dataset_cache=None)
+        encodings_cache = {}
         with NLGEvalOutput(os.path.join(env_utils.OUTPUT_DIR, args.output_dir), domain_name) as nlgeval:
             for dialogue in domain_dialogues:
                 dialogue_id = dialogue['id']
@@ -161,8 +162,8 @@ def main(args):
                     optimizer.lr = args.lr
 
                     fine_tune(model, tokenizer, optimizer, supset, args, amp=amp_handle)
+                    encodings_cache = {}
 
-                encodings_cache = {}
                 if args.local_rank in [0, -1]:
                     turn_to_predict = spec['predict_turn']
                     ret_window = (turn_to_predict - args.retrieval_window // 2,
@@ -174,9 +175,9 @@ def main(args):
                         for sup_turn_to_predict in range(ret_window[0], ret_window[1] + 1):
                             if not sup_turn_to_predict < len(support_dialogue['turns']):
                                 continue
-                            support_dlg_history = support_dialogue['turns'][:turn_to_predict]
+                            support_dlg_history = support_dialogue['turns'][:sup_turn_to_predict]
                             support_dlg_history = support_dlg_history[-(args.max_history * 2 - 1):]
-                            support_response = support_dialogue['turns'][turn_to_predict]
+                            support_response = support_dialogue['turns'][sup_turn_to_predict]
                             support_contexts.append(support_dlg_history)
                             support_responses.append(support_response)
                     with torch.no_grad():


### PR DESCRIPTION
- `--retrieval_window` cmdline arg added setting how many support contexts/responses of each dialogue to consider as retrieval candidates.
- encodings cache implemented in order to re-use encoded contexts across predictions. Mainly useful in 0-shot adaptation when the model is fixed (and so are the encodings)
- NSP accuracy logging fixed

@aatkinson @temporaer